### PR TITLE
load autoprefixer locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,14 @@
 # the following line to use "https"
 source 'http://rubygems.org'
 
-gem "middleman", '~>3.3.4'
+gem "middleman"
 gem "middleman-s3_sync"
 
 # Live-reloading plugin
 gem "middleman-livereload"
+
+# Autoprefixer
+gem "middleman-autoprefixer"
 
 # Belly style rolodex
 gem "rolodex", github: "bellycard/rolodex"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 3.3.4)
+  middleman
+  middleman-autoprefixer
   middleman-livereload
   middleman-s3_sync
   pry


### PR DESCRIPTION
@bellycard/apps

In reference to: bellycard/rolodex#70

We were already using autoprefixer, but it was loaded out of Rolodex. Adding the gem to our own Gemfile should make the future-proof when Rolodex updates.

`style` was pinned to a specific version of middleman, which was not allowing me to install middleman-autoprefixer... I took out that dependency, and we're good now. I ran everything locally, and it all looks fine.
